### PR TITLE
Fallback to message name

### DIFF
--- a/client/views/home/home.html
+++ b/client/views/home/home.html
@@ -21,5 +21,9 @@
 </template>
 
 <template name="conversationListItem">
-  <a href="/conversation/{{_id}}"><li class="{{active}}"><img class="avatar" src={{avatarUrl}} /> {{name}}</li></a>
+  <a href="/conversation/{{_id}}">
+    <li>
+      <img class="avatar" src={{avatarUrl}} />{{name}}
+    </li>
+  </a>
 </template>

--- a/server/methods.js
+++ b/server/methods.js
@@ -14,8 +14,10 @@ Meteor.methods({
     return SmoochApi.appUsers.get({
       appId: Meteor.settings.smoochAppId,
       userId
-    }).then(({appUser}) => Utils.resolveAvatarUrl(appUser))
-      .catch(console.error)
+    }).then(({appUser}) => {
+      appUser.avatarUrl = Utils.resolveAvatarUrl(appUser)
+      return appUser
+    }).catch(console.error)
     /* */
   }
 });

--- a/server/utils.js
+++ b/server/utils.js
@@ -13,8 +13,6 @@ Utils.resolveAvatarUrl = function resolveAvatarUrl(appUser) {
     avatarUrl = `https://www.gravatar.com/avatar/${hash}.png?s=100&d=retro&t=${Date.now()}`
   }
 
-  return Object.assign(appUser, {
-    avatarUrl
-  })
+  return avatarUrl;
 }
 


### PR DESCRIPTION
If appUser does not have `givenName` or `surname`, fallback to `message.name` instead of generating an anonymous one.

![screen shot 2017-02-07 at 1 00 59 pm](https://cloud.githubusercontent.com/assets/2432382/22704389/85d6edfa-ed35-11e6-8df7-51e1c99c479e.png)
