### PR TITLE
Add support for automatic translations

### DIFF
--- a/client/views/conversation/conversation.html
+++ b/client/views/conversation/conversation.html
@@ -44,6 +44,10 @@
               {{> audioMessage}}
             {{else}}
               {{#markdown}}{{{text}}}{{/markdown}}
+              {{#if metadata.translation}}
+                {{#markdown}}---{{/markdown}}
+                {{#markdown}}Translation: _{{{metadata.translation}}}_{{/markdown}}
+              {{/if}}
             {{/if}}
           {{/if}}
           {{#if actions}}

--- a/client/views/conversation/conversation.html
+++ b/client/views/conversation/conversation.html
@@ -46,7 +46,8 @@
               {{#markdown}}{{{text}}}{{/markdown}}
               {{#if metadata.translation}}
                 {{#markdown}}---{{/markdown}}
-                {{#markdown}}Translation: _{{{metadata.translation}}}_{{/markdown}}
+                {{#markdown}}**{{{metadata.translationAction}}}:**{{/markdown}}
+                {{#markdown}}*{{{metadata.translation}}}*:{{/markdown}}
               {{/if}}
             {{/if}}
           {{/if}}


### PR DESCRIPTION
If message has a translation key in metadata object, display it.

![screen shot 2017-03-27 at 3 14 18 pm](https://cloud.githubusercontent.com/assets/2235885/24373687/293e727a-1300-11e7-8c69-938c07f37619.png)

